### PR TITLE
Improved handling of Svelte files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "Design System Linter" extension will be documented in this file.
 
+
+## [0.2.1] - 2024-10-23
+### Changed
+- Updated the way Svelte files are parsed to ensure that the extension only lints the contents of the `<style>` tag.
+  - This does mean that in-line styles in Svelte files will not be linted by the extension.
+
 ## [0.2.0] - 2024-10-20
 ### Added
 - Granular linting controls for spacing and colors.

--- a/examples/style.svelte
+++ b/examples/style.svelte
@@ -4,12 +4,15 @@
 </script>
 
 <main>
-  <h1>{title}</h1>
-  <p>{subtitle}</p>
+  <!-- Styles here should not be linted -->
+  <h1 style="color: #f618fa">{title}</h1>
+  <p style="margin-left: 20px">{subtitle}</p>
   <img src="https://via.placeholder.com/500" alt="Placeholder" />
 </main>
 
 <style>
+  /* Styles here will be linted */
+
   /* Reset styles */
   *,
   *::before,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/ObieMunoz/vsce-design-system-linter"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "vscode": "^1.63.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,14 +235,18 @@ function handleSpacingValue(
 ): void {
   const valueString = match[2].trim();
   const values = valueString.match(/(\d+(?:\.\d+)?(?:px|rem))/g) || [];
+  const isSvelteFile = document.languageId === "svelte";
+  const fullText = document.getText();
 
   values.forEach((valueWithUnit) => {
     const unit = valueWithUnit.endsWith("px") ? "px" : "rem";
     const value = parseFloat(valueWithUnit);
 
-    const startPosition = document.positionAt(
-      (match.index ?? 0) + match[0].indexOf(valueWithUnit)
-    );
+    const valueOffset = (match.index ?? 0) + match[0].indexOf(valueWithUnit);
+    const adjustedOffset = isSvelteFile
+      ? adjustSveltePosition(valueOffset, fullText)
+      : valueOffset;
+    const startPosition = document.positionAt(adjustedOffset);
     const endPosition = startPosition.translate(0, valueWithUnit.length);
     const range = new vscode.Range(startPosition, endPosition);
 
@@ -254,7 +258,6 @@ function handleSpacingValue(
     }
 
     const message = `DESIGN SYSTEM: Consider using '${recommendation}' instead of '${valueWithUnit}'.`;
-
     diagnostics.push(
       new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Warning)
     );
@@ -267,7 +270,6 @@ function handleSpacingValue(
         },
       },
     };
-
     decorations.push(decoration);
   });
 }
@@ -287,14 +289,19 @@ function handleColorValue(
   decorations: vscode.DecorationOptions[]
 ): void {
   let colorValue = match[2].trim();
-
   if (colorValue.length === 4) {
     colorValue = `#${colorValue[1]}${colorValue[1]}${colorValue[2]}${colorValue[2]}${colorValue[3]}${colorValue[3]}`;
   }
 
-  const valueIndex =
+  const isSvelteFile = document.languageId === "svelte";
+  const fullText = document.getText();
+  const valueOffset =
     (match.index ?? 0) + match[0].indexOf(colorValue.slice(0, 3));
-  const startPosition = document.positionAt(valueIndex);
+  const adjustedOffset = isSvelteFile
+    ? adjustSveltePosition(valueOffset, fullText)
+    : valueOffset;
+
+  const startPosition = document.positionAt(adjustedOffset);
   const endPosition = startPosition.translate(0, colorValue.length);
   const range = new vscode.Range(startPosition, endPosition);
 
@@ -309,6 +316,7 @@ function handleColorValue(
     diagnostics.push(
       new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Warning)
     );
+
     const decoration: vscode.DecorationOptions = {
       range,
       renderOptions: {
@@ -317,15 +325,15 @@ function handleColorValue(
         },
       },
     };
-
     decorations.push(decoration);
   } else {
     const nearestToken = findClosestColorToken(colorValue);
-
     const message = `DESIGN SYSTEM: Consider using '${nearestToken}' instead of '${colorValue}'.`;
+
     diagnostics.push(
       new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Warning)
     );
+
     const decoration: vscode.DecorationOptions = {
       range,
       renderOptions: {
@@ -334,7 +342,6 @@ function handleColorValue(
         },
       },
     };
-
     decorations.push(decoration);
   }
 }
@@ -360,7 +367,13 @@ function lintDocument(document: vscode.TextDocument): void {
   const diagnostics: vscode.Diagnostic[] = [];
   const decorations: vscode.DecorationOptions[] = [];
 
-  const text = document.getText();
+  let textToLint: string;
+
+  if (document.languageId === "svelte") {
+    textToLint = extractStyleTagContents(document.getText());
+  } else {
+    textToLint = document.getText();
+  }
 
   let match: RegExpExecArray | null;
 
@@ -368,7 +381,7 @@ function lintDocument(document: vscode.TextDocument): void {
   if (enableSpacingLint) {
     const spacingRegex =
       /([\w-]+)\s*:\s*([\d\s]*(?:\d+(?:\.\d+)?(?:px|rem)\b\s*)+)/g;
-    while ((match = spacingRegex.exec(text)) !== null) {
+    while ((match = spacingRegex.exec(textToLint)) !== null) {
       handleSpacingValue(match, document, diagnostics, decorations);
     }
   }
@@ -376,7 +389,7 @@ function lintDocument(document: vscode.TextDocument): void {
   // Handle color values
   if (enableColorLint) {
     const colorRegex = /([\w-]+)\s*:\s*(#[0-9a-fA-F]{3,8})/g;
-    while ((match = colorRegex.exec(text)) !== null) {
+    while ((match = colorRegex.exec(textToLint)) !== null) {
       handleColorValue(match, document, diagnostics, decorations);
     }
   }
@@ -386,6 +399,48 @@ function lintDocument(document: vscode.TextDocument): void {
   if (activeTextEditor && activeTextEditor.document.uri === document.uri) {
     activeTextEditor.setDecorations(recommendationDecorationType, decorations);
   }
+}
+
+/**
+ * @description Extracts contents of all style tags from a Svelte file
+ * @param {string} text - The full text content of the Svelte file
+ * @returns {string} Concatenated contents of all style tags
+ */
+function extractStyleTagContents(text: string): string {
+  const styleTagRegex = /<style[^>]*>([\s\S]*?)<\/style>/g;
+  let styleContents: string[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = styleTagRegex.exec(text)) !== null) {
+    styleContents.push(match[1]);
+  }
+
+  return styleContents.join("\n");
+}
+
+/**
+ * @description Updates position information for diagnostics and decorations in Svelte files
+ * @param {number} offset - The offset within the style tag
+ * @param {string} fullText - The full document text
+ * @returns {number} The actual position in the document
+ */
+function adjustSveltePosition(offset: number, fullText: string): number {
+  const styleTagRegex = /<style[^>]*>([\s\S]*?)<\/style>/g;
+  let currentOffset = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = styleTagRegex.exec(fullText)) !== null) {
+    const styleContent = match[1];
+    const styleTagStart = match.index + match[0].indexOf(">") + 1;
+
+    if (currentOffset + styleContent.length >= offset) {
+      return styleTagStart + (offset - currentOffset);
+    }
+
+    currentOffset += styleContent.length + 1;
+  }
+
+  return offset;
 }
 
 /**


### PR DESCRIPTION
**Problem**
When editing Svelte files, the linter will occasionally offer Code Actions to replace random words in the script or markup sections with recommendations.

**Solution**
Updated the Code Action Provider and handlers for Color & Spacing values to only apply suggestions or code action recommendations within a `<style>` block in Svelte files.

Resolves #2 